### PR TITLE
feat:(feat/upload-user-avatar): CB-8:upload user avatar api

### DIFF
--- a/Controllers/upload.controller.js
+++ b/Controllers/upload.controller.js
@@ -1,5 +1,6 @@
 const uploadService = require('../Services/upload.service');
 const { catchAsync } = require('../Utils/error.utils');
+const { AppError } = require('../Utils/error.utils');
 
 /**
  * Controller for handling file uploads
@@ -25,6 +26,29 @@ class UploadController {
       message: 'Upload completed',
       data: success,
       failed: failed.length ? failed : undefined,
+    });
+  });
+
+  /**
+   * Update user avatar using uploaded media
+   * @param {Object} req - Express request object
+   * @param {Object} res - Express response object
+   * @param {Function} _next - Express next function
+   */
+  updateUserAvatar = catchAsync(async (req, res, _next) => {
+    const { mediaId } = req.body;
+    const userId = req.user._id;
+
+    if (!mediaId) {
+      throw new AppError('Media ID is required', 400);
+    }
+
+    const result = await uploadService.updateUserAvatar(mediaId, userId);
+
+    return res.status(200).json({
+      status: 'success',
+      message: 'User avatar updated successfully',
+      data: result,
     });
   });
 }

--- a/OpenApi/upload/avatar.yaml
+++ b/OpenApi/upload/avatar.yaml
@@ -1,0 +1,148 @@
+openapi: 3.0.0
+info:
+  title: Upload Avatar API
+  version: 1.0.0
+  description: API for updating user avatar using uploaded media
+
+paths:
+  /api/upload/avatar:
+    patch:
+      tags:
+        - Upload
+      summary: Update user avatar using uploaded media
+      description: |
+        Update user avatar by linking an uploaded media file to the user.
+        - Requires a valid JWT token
+        - mediaId must be from a successful upload
+      security:
+        - BearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - mediaId
+              properties:
+                mediaId:
+                  type: string
+                  description: ID of the uploaded media file
+                  example: "65f1a2b3c4d5e6f7g8h9i0j1"
+      responses:
+        '200':
+          description: Avatar updated successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                    example: success
+                  message:
+                    type: string
+                    example: User avatar updated successfully
+                  data:
+                    type: object
+                    properties:
+                      _id:
+                        type: string
+                        example: "65f1a2b3c4d5e6f7g8h9i0j1"
+                      email:
+                        type: string
+                        example: "user@example.com"
+                      avatar:
+                        type: string
+                        example: "https://storage.bizflycloud.vn/AVATAR/1234567890-avatar.jpg"
+                      name:
+                        type: string
+                        example: "John Doe"
+                      role:
+                        type: string
+                        example: "BUYER"
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                    example: error
+                  message:
+                    type: string
+              examples:
+                missingMediaId:
+                  value:
+                    status: error
+                    message: "Media ID is required"
+                invalidMediaId:
+                  value:
+                    status: error
+                    message: "Invalid mediaId format"
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                    example: error
+                  message:
+                    type: string
+              examples:
+                noToken:
+                  value:
+                    status: error
+                    message: "Access token is required"
+                invalidToken:
+                  value:
+                    status: error
+                    message: "Invalid token"
+                expiredToken:
+                  value:
+                    status: error
+                    message: "Token has expired"
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - type: object
+                    properties:
+                      status:
+                        type: string
+                        example: error
+                      message:
+                        type: string
+                        example: Media not found
+                  - type: object
+                    properties:
+                      status:
+                        type: string
+                        example: error
+                      message:
+                        type: string
+                        example: User not found
+        '500':
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                    example: error
+                  message:
+                    type: string
+              examples:
+                processingError:
+                  value:
+                    status: error
+                    message: "Failed to update avatar" 

--- a/Routes/upload.route.js
+++ b/Routes/upload.route.js
@@ -20,4 +20,11 @@ router.post(
   uploadController.uploadFile
 );
 
+/**
+ * @route PATCH /api/upload/avatar
+ * @desc Update user avatar using uploaded media
+ * @access Private
+ */
+router.patch('/avatar', verifyToken(), uploadController.updateUserAvatar);
+
 module.exports = router;

--- a/Services/upload.service.js
+++ b/Services/upload.service.js
@@ -1,10 +1,14 @@
 const { S3Client, PutObjectCommand, DeleteObjectCommand } = require('@aws-sdk/client-s3');
 const { AppError } = require('../Utils/error.utils');
-const { MEDIA_TYPE, SUPPORTED_FILE_TYPES } = require('../Utils/constant');
+const { MEDIA_TYPE, SUPPORTED_FILE_TYPES, IMAGE_OWNER_TYPE } = require('../Utils/constant');
 const Media = require('../Models/media.model');
+const User = require('../Models/user.model');
+const BaseService = require('./base.service');
+const mongoose = require('mongoose');
 
-class UploadService {
+class UploadService extends BaseService {
   constructor() {
+    super(Media);
     this.s3 = new S3Client({
       region: process.env.BIZFLY_REGION,
       endpoint: process.env.BIZFLY_ENDPOINT,
@@ -70,6 +74,38 @@ class UploadService {
       }
       throw new AppError(`Failed to upload file: ${error.message}`, 400);
     }
+  }
+
+  /**
+   * Update user avatar using uploaded media
+   * @param {string} mediaId - ID of the uploaded media
+   * @param {string} userId - ID of the user
+   * @returns {Promise<Object>} Updated user object
+   */
+  async updateUserAvatar(mediaId, userId) {
+    if (!mongoose.Types.ObjectId.isValid(mediaId)) {
+      throw new AppError('Invalid mediaId format', 400);
+    }
+    // Find media by ID
+    const media = await this.getById(mediaId);
+    if (!media) {
+      throw new AppError('Media not found', 404);
+    }
+
+    // Update media with owner info
+    await this.update(mediaId, {
+      ownerType: IMAGE_OWNER_TYPE.USER,
+      ownerId: userId,
+    });
+
+    // Update user avatar
+    const updatedUser = await User.findByIdAndUpdate(userId, { avatar: media.url }, { new: true });
+
+    if (!updatedUser) {
+      throw new AppError('User not found', 404);
+    }
+
+    return updatedUser.toPublicJSON();
   }
 }
 


### PR DESCRIPTION
### Description

- Link to Jira: https://duongrong2012-1743575833445.atlassian.net/browse/CB-8

---

### Summary

- [x] To use the Upload User Avatar API, the user must first authenticate by logging in and then supply the ownerId  
- [x] Provided Swagger documentation for the upload user avatar api endpoint
- [x] Validate JWT token (require Bearer token for authentication)
- [x] Validate that mediaId is provided in the request body
- [x] Validate that mediaId is in correct MongoDB ObjectId format
- [x] Check if media with the given mediaId exists in the database
- [x] Check if user (from token) exists in the database
- [x] Update the media record with correct ownerType and ownerId
- [x] Update the user's avatar field with the media's URL