### PR TITLE
feat(get-province):CB-34:get provinces api

### DIFF
--- a/Controllers/province.controller.js
+++ b/Controllers/province.controller.js
@@ -1,0 +1,24 @@
+const ProvinceService = require('../Services/province.service');
+const response = require('../Utils/response.utils');
+const { catchAsync } = require('../Utils/error.utils');
+
+/**
+ * ProvinceController handles province API requests.
+ * Only receives validated data from middleware, calls service, and returns response.
+ */
+class ProvinceController {
+  /**
+   * Get list of provinces (with optional pagination)
+   * @route GET /provinces
+   * @access Public
+   */
+  getProvinces = catchAsync(async (req, res) => {
+    const { page, limit } = req.validatedData;
+    const serviceResult = await ProvinceService.getProvinces({ page, limit });
+    return res.json(
+      response.success('Get provinces successfully', response.groupPagination(serviceResult))
+    );
+  });
+}
+
+module.exports = new ProvinceController();

--- a/JSON/province.json
+++ b/JSON/province.json
@@ -1,0 +1,240 @@
+{
+  "11": {
+    "name": "Hà Nội",
+    "slug": "ha-noi",
+    "type": "thanh-pho",
+    "name_with_type": "Thành phố Hà Nội",
+    "code": "11"
+  },
+  "12": {
+    "name": "Hồ Chí Minh",
+    "slug": "ho-chi-minh",
+    "type": "thanh-pho",
+    "name_with_type": "Thành phố Hồ Chí Minh",
+    "code": "12"
+  },
+  "13": {
+    "name": "Đà Nẵng",
+    "slug": "da-nang",
+    "type": "thanh-pho",
+    "name_with_type": "Thành phố Đà Nẵng",
+    "code": "13"
+  },
+  "14": {
+    "name": "Hải Phòng",
+    "slug": "hai-phong",
+    "type": "thanh-pho",
+    "name_with_type": "Thành phố Hải Phòng",
+    "code": "14"
+  },
+  "15": {
+    "name": "Cần Thơ",
+    "slug": "can-tho",
+    "type": "thanh-pho",
+    "name_with_type": "Thành phố Cần Thơ",
+    "code": "15"
+  },
+  "16": {
+    "name": "Huế",
+    "slug": "hue",
+    "type": "thanh-pho",
+    "name_with_type": "Thành phố Huế",
+    "code": "16"
+  },
+  "17": {
+    "name": "An Giang",
+    "slug": "an-giang",
+    "type": "tinh",
+    "name_with_type": "Tỉnh An Giang",
+    "code": "17"
+  },
+  "18": {
+    "name": "Bắc Ninh",
+    "slug": "bac-ninh",
+    "type": "tinh",
+    "name_with_type": "Tỉnh Bắc Ninh",
+    "code": "18"
+  },
+  "19": {
+    "name": "Cà Mau",
+    "slug": "ca-mau",
+    "type": "tinh",
+    "name_with_type": "Tỉnh Cà Mau",
+    "code": "19"
+  },
+  "20": {
+    "name": "Cao Bằng",
+    "slug": "cao-bang",
+    "type": "tinh",
+    "name_with_type": "Tỉnh Cao Bằng",
+    "code": "20"
+  },
+  "21": {
+    "name": "Đắk Lắk",
+    "slug": "dak-lak",
+    "type": "tinh",
+    "name_with_type": "Tỉnh Đắk Lắk",
+    "code": "21"
+  },
+  "22": {
+    "name": "Điện Biên",
+    "slug": "dien-bien",
+    "type": "tinh",
+    "name_with_type": "Tỉnh Điện Biên",
+    "code": "22"
+  },
+  "23": {
+    "name": "Đồng Nai",
+    "slug": "dong-nai",
+    "type": "tinh",
+    "name_with_type": "Tỉnh Đồng Nai",
+    "code": "23"
+  },
+  "24": {
+    "name": "Đồng Tháp",
+    "slug": "dong-thap",
+    "type": "tinh",
+    "name_with_type": "Tỉnh Đồng Tháp",
+    "code": "24"
+  },
+  "25": {
+    "name": "Gia Lai",
+    "slug": "gia-lai",
+    "type": "tinh",
+    "name_with_type": "Tỉnh Gia Lai",
+    "code": "25"
+  },
+  "26": {
+    "name": "Hà Tĩnh",
+    "slug": "ha-tinh",
+    "type": "tinh",
+    "name_with_type": "Tỉnh Hà Tĩnh",
+    "code": "26"
+  },
+  "27": {
+    "name": "Hưng Yên",
+    "slug": "hung-yen",
+    "type": "tinh",
+    "name_with_type": "Tỉnh Hưng Yên",
+    "code": "27"
+  },
+  "28": {
+    "name": "Khánh Hòa",
+    "slug": "khanh-hoa",
+    "type": "tinh",
+    "name_with_type": "Tỉnh Khánh Hòa",
+    "code": "28"
+  },
+  "29": {
+    "name": "Lai Châu",
+    "slug": "lai-chau",
+    "type": "tinh",
+    "name_with_type": "Tỉnh Lai Châu",
+    "code": "29"
+  },
+  "30": {
+    "name": "Lâm Đồng",
+    "slug": "lam-dong",
+    "type": "tinh",
+    "name_with_type": "Tỉnh Lâm Đồng",
+    "code": "30"
+  },
+  "31": {
+    "name": "Lạng Sơn",
+    "slug": "lang-son",
+    "type": "tinh",
+    "name_with_type": "Tỉnh Lạng Sơn",
+    "code": "31"
+  },
+  "32": {
+    "name": "Lào Cai",
+    "slug": "lao-cai",
+    "type": "tinh",
+    "name_with_type": "Tỉnh Lào Cai",
+    "code": "32"
+  },
+  "33": {
+    "name": "Nghệ An",
+    "slug": "nghe-an",
+    "type": "tinh",
+    "name_with_type": "Tỉnh Nghệ An",
+    "code": "33"
+  },
+  "34": {
+    "name": "Ninh Bình",
+    "slug": "ninh-binh",
+    "type": "tinh",
+    "name_with_type": "Tỉnh Ninh Bình",
+    "code": "34"
+  },
+  "35": {
+    "name": "Phú Thọ",
+    "slug": "phu-tho",
+    "type": "tinh",
+    "name_with_type": "Tỉnh Phú Thọ",
+    "code": "35"
+  },
+  "36": {
+    "name": "Quảng Ngãi",
+    "slug": "quang-ngai",
+    "type": "tinh",
+    "name_with_type": "Tỉnh Quảng Ngãi",
+    "code": "36"
+  },
+  "37": {
+    "name": "Quảng Ninh",
+    "slug": "quang-ninh",
+    "type": "tinh",
+    "name_with_type": "Tỉnh Quảng Ninh",
+    "code": "37"
+  },
+  "38": {
+    "name": "Quảng Trị",
+    "slug": "quang-tri",
+    "type": "tinh",
+    "name_with_type": "Tỉnh Quảng Trị",
+    "code": "38"
+  },
+  "39": {
+    "name": "Sơn La",
+    "slug": "son-la",
+    "type": "tinh",
+    "name_with_type": "Tỉnh Sơn La",
+    "code": "39"
+  },
+  "40": {
+    "name": "Tây Ninh",
+    "slug": "tay-ninh",
+    "type": "tinh",
+    "name_with_type": "Tỉnh Tây Ninh",
+    "code": "40"
+  },
+  "41": {
+    "name": "Thái Nguyên",
+    "slug": "thai-nguyen",
+    "type": "tinh",
+    "name_with_type": "Tỉnh Thái Nguyên",
+    "code": "41"
+  },
+  "42": {
+    "name": "Thanh Hóa",
+    "slug": "thanh-hoa",
+    "type": "tinh",
+    "name_with_type": "Tỉnh Thanh Hóa",
+    "code": "42"
+  },
+  "43": {
+    "name": "Tuyên Quang",
+    "slug": "tuyen-quang",
+    "type": "tinh",
+    "name_with_type": "Tỉnh Tuyên Quang",
+    "code": "43"
+  },
+  "44": {
+    "name": "Vĩnh Long",
+    "slug": "vinh-long",
+    "type": "tinh",
+    "name_with_type": "Tỉnh Vĩnh Long",
+    "code": "44"
+  }
+}

--- a/Middlewares/province-validation.js
+++ b/Middlewares/province-validation.js
@@ -1,0 +1,34 @@
+const { AppError } = require('../Utils/error.utils');
+
+/**
+ * Validate and sanitize query parameters for getting provinces.
+ * Only allows positive integer for page and limit if provided.
+ * Default: page=1, limit=20
+ */
+module.exports = (req, res, next) => {
+  const { page, limit } = req.query;
+  let validated = {};
+
+  // Default values
+  validated.page = 1;
+  validated.limit = 20;
+
+  if (page !== undefined) {
+    const pageNum = Number(page);
+    if (!Number.isInteger(pageNum) || pageNum <= 0) {
+      return next(new AppError(400, 'Page must be a positive integer.'));
+    }
+    validated.page = pageNum;
+  }
+
+  if (limit !== undefined) {
+    const limitNum = Number(limit);
+    if (!Number.isInteger(limitNum) || limitNum <= 0) {
+      return next(new AppError(400, 'Limit must be a positive integer.'));
+    }
+    validated.limit = limitNum;
+  }
+
+  req.validatedData = validated;
+  next();
+};

--- a/Models/province.model.js
+++ b/Models/province.model.js
@@ -1,0 +1,50 @@
+const mongoose = require('mongoose');
+
+/**
+ * Province Schema
+ * @typedef {object} Province
+ * @property {string} code - Province code (unique, required)
+ * @property {string} name - Province name (required)
+ * @property {string} slug - Province slug (required)
+ * @property {string} type - Province type (required)
+ * @property {string} name_with_type - Full name with type (required)
+ */
+const provinceSchema = new mongoose.Schema(
+  {
+    code: {
+      type: String,
+      required: true,
+      unique: true,
+      trim: true,
+    },
+    name: {
+      type: String,
+      required: true,
+      trim: true,
+    },
+    slug: {
+      type: String,
+      required: true,
+      trim: true,
+    },
+    type: {
+      type: String,
+      required: true,
+      trim: true,
+    },
+    name_with_type: {
+      type: String,
+      required: true,
+      trim: true,
+    },
+  },
+  {
+    timestamps: false,
+    versionKey: false,
+    collection: 'provinces',
+  }
+);
+
+provinceSchema.plugin(require('mongoose-paginate-v2'));
+
+module.exports = mongoose.model('Province', provinceSchema);

--- a/OpenApi/buyer/get-provinces.yaml
+++ b/OpenApi/buyer/get-provinces.yaml
@@ -1,0 +1,105 @@
+openapi: 3.0.0
+info:
+  title: Get Provinces
+  description: Get list of provinces
+  version: 1.0.0
+
+servers:
+  - url: http://localhost:3000
+
+paths:
+  /buyer/provinces:
+    get:
+      summary: Get list of provinces
+      tags:
+        - Province
+      parameters:
+        - in: query
+          name: page
+          schema:
+            type: integer
+            minimum: 1
+          required: false
+          description: Page number for pagination
+        - in: query
+          name: limit
+          schema:
+            type: integer
+            minimum: 1
+          required: false
+          description: Number of items per page
+      responses:
+        '200':
+          description: List of provinces
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                    example: success
+                  message:
+                    type: string
+                    example: Get provinces successfully
+                  data:
+                    type: object
+                    properties:
+                      docs:
+                        type: array
+                        items:
+                          $ref: '#/components/schemas/Province'
+                      totalDocs:
+                        type: integer
+                        example: 44
+                      limit:
+                        type: integer
+                        example: 10
+                      page:
+                        type: integer
+                        example: 1
+                      totalPages:
+                        type: integer
+                        example: 5
+                      hasNextPage:
+                        type: boolean
+                        example: true
+                      hasPrevPage:
+                        type: boolean
+                        example: false
+        '400':
+          description: Invalid query params
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
+components:
+  schemas:
+    Province:
+      type: object
+      properties:
+        code:
+          type: string
+          example: '11'
+        name:
+          type: string
+          example: 'Hà Nội'
+        slug:
+          type: string
+          example: 'ha-noi'
+        type:
+          type: string
+          example: 'thanh-pho'
+        name_with_type:
+          type: string
+          example: 'Thành phố Hà Nội'
+    Error:
+      type: object
+      properties:
+        status:
+          type: string
+          example: error
+        message:
+          type: string
+          example: Page must be a positive integer. 

--- a/README.md
+++ b/README.md
@@ -61,6 +61,31 @@ This command executes the seeder script located at `seeders/update-product-statu
 
 **Note**: This seeder is safe to run multiple times - it will only update products that need the status field added.
 
+## Province Seeder
+
+This project includes a seeder script to import all provinces from `province.json` into the MongoDB `provinces` collection.
+
+### Usage
+
+1. **Ensure your `.env` file contains a valid `MONGO_URI` for your MongoDB instance.**
+2. Run the following command from the project root:
+
+```bash
+npm run seed:province
+```
+
+- The script will connect to your database, remove all existing provinces, and import the new data.
+- You should see `Provinces seeded successfully!` if the operation completes without errors.
+
+**Alternatively, you can run the script directly:**
+```bash
+node seeders/province-seeder.js
+```
+
+### Notes
+- This operation is destructive: it will delete all existing provinces before importing.
+- Make sure your database connection string is correct and you have the necessary permissions.
+
 ## API Endpoints
 
 ### Authentication

--- a/Routes/buyer.route.js
+++ b/Routes/buyer.route.js
@@ -15,6 +15,8 @@ const {
 } = require('../Middlewares');
 const cartController = require('../Controllers/cart.controller');
 const { validateAddCart, validateGetCart } = require('../Middlewares/cart-validation');
+const provinceValidation = require('../Middlewares/province-validation');
+const provinceController = require('../Controllers/province.controller');
 
 // Protected routes
 router.get('/profile', verifyToken(), buyerController.getProfile);
@@ -50,5 +52,7 @@ router.post('/cart', verifyToken(), validateAddCart, cartController.addCart);
 
 // Get paginated cart
 router.get('/cart', verifyToken(), validateGetCart, cartController.getCart);
+
+router.get('/provinces', provinceValidation, provinceController.getProvinces);
 
 module.exports = router;

--- a/Services/province.service.js
+++ b/Services/province.service.js
@@ -1,0 +1,28 @@
+const BaseService = require('./base.service');
+const Province = require('../Models/province.model');
+const { groupPagination } = require('../Utils/response.utils');
+
+/**
+ * ProvinceService handles business logic for province operations.
+ * Extends BaseService for common CRUD and pagination.
+ */
+class ProvinceService extends BaseService {
+  constructor() {
+    super(Province);
+  }
+
+  /**
+   * Get list of provinces with optional pagination
+   * @param {object} options - Pagination options { page, limit }
+   * @returns {object} - { data, message }
+   */
+  async getProvinces({ page, limit }) {
+    const result = await this.paginate({ page, limit }, {});
+    return {
+      data: groupPagination(result),
+      message: 'Get provinces successfully',
+    };
+  }
+}
+
+module.exports = new ProvinceService();

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "format:check": "prettier --check .",
     "seed:super-admin": "node seeders/create-super-admin.js",
     "seed:update-product-status": "node seeders/update-product-status.js",
+    "seed:province": "node seeders/province-seeder.js",
     "prepare": "husky install"
   },
   "dependencies": {

--- a/seeders/province-seeder.js
+++ b/seeders/province-seeder.js
@@ -1,0 +1,28 @@
+require('dotenv').config();
+const mongoose = require('mongoose');
+const Province = require('../Models/province.model');
+const fs = require('fs');
+const path = require('path');
+
+/**
+ * Seeder script to import provinces from province.json into MongoDB
+ */
+async function seedProvinces() {
+  try {
+    const dataPath = path.join(__dirname, '../JSON/province.json');
+    const rawData = fs.readFileSync(dataPath, 'utf-8');
+    const provincesObj = JSON.parse(rawData);
+    const provinces = Object.values(provincesObj);
+
+    await mongoose.connect(process.env.MONGO_URI);
+    await Province.deleteMany({});
+    await Province.insertMany(provinces);
+    console.log('Provinces seeded successfully!');
+    process.exit(0);
+  } catch (err) {
+    console.error('Province seeding failed:', err);
+    process.exit(1);
+  }
+}
+
+seedProvinces();


### PR DESCRIPTION
### Description

- Link to Jira: https://duongrong2012-1743575833445.atlassian.net/browse/CB-34

---

### Summary

- [x] Implemented API to get list of provinces with pagination
- [x] Created `Province` model and schema based on province.json structure
- [x] Added service, controller, middleware, and route for province retrieval
- [x] Ensured default pagination values and input validation in middleware
- [x] Integrated mongoose-paginate-v2 for efficient data retrieval
- [x] Provided Swagger documentation for the get-provinces endpoint
- [x] Added seeder script to import province data from province.json
- [x] Updated README with instructions for running the province seeder