### PR TITLE
feat(get-voucher-for-seller):CB-42:get voucher for seller api

### DIFF
--- a/Controllers/voucher.controller.js
+++ b/Controllers/voucher.controller.js
@@ -65,6 +65,16 @@ class VoucherController {
     const result = await voucherService.getVouchersAdmin(req.query);
     res.json(response.success('Vouchers retrieved successfully', response.groupPagination(result)));
   });
+
+  /**
+   * Get vouchers for seller (only own vouchers)
+   * @route GET /buyer/vouchers
+   * @access Seller
+   */
+  getVouchersSeller = catchAsync(async (req, res) => {
+    const result = await voucherService.getVouchersSeller(req.query, req.user._id);
+    res.json(response.success('Vouchers retrieved successfully', response.groupPagination(result)));
+  });
 }
 
 module.exports = new VoucherController();

--- a/Middlewares/voucher-validation.middleware.js
+++ b/Middlewares/voucher-validation.middleware.js
@@ -1252,10 +1252,63 @@ const validateGetVouchersAdmin = [
   },
 ];
 
+const validateGetVouchersSeller = [
+  query('code').optional().isString().withMessage('Code must be a string.'),
+  query('status').optional().isIn(Object.values(VOUCHER_STATUS)).withMessage('Status is invalid.'),
+  query('type').optional().isIn(Object.values(VOUCHER_TYPE)).withMessage('Type is invalid.'),
+  query('source').optional().isIn(['SYSTEM', 'SHOP']).withMessage('Source is invalid.'),
+  query('isActive').optional().isBoolean().withMessage('isActive must be boolean.').toBoolean(),
+  query('isPublic').optional().isBoolean().withMessage('isPublic must be boolean.').toBoolean(),
+  query('minOrderValue').optional().isNumeric().withMessage('minOrderValue must be a number.'),
+  query('maxDiscount').optional().isNumeric().withMessage('maxDiscount must be a number.'),
+  query('discountValue').optional().isNumeric().withMessage('discountValue must be a number.'),
+  query('quantity').optional().isInt().withMessage('quantity must be an integer.'),
+  query('startDate')
+    .optional()
+    .isISO8601()
+    .withMessage('startDate must be a valid ISO8601 date string.'),
+  query('endDate')
+    .optional()
+    .isISO8601()
+    .withMessage('endDate must be a valid ISO8601 date string.'),
+  (req, res, next) => {
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      const formatted = errors.array().map(err => ({ field: err.path, message: err.msg }));
+      return next(new AppError('Validation failed', 400, formatted));
+    }
+    // Only allow listed fields from client.
+    const allowedFields = [
+      'code',
+      'status',
+      'type',
+      'source',
+      'isActive',
+      'isPublic',
+      'minOrderValue',
+      'maxDiscount',
+      'discountValue',
+      'quantity',
+      'startDate',
+      'endDate',
+      'page',
+      'limit',
+      'sortBy',
+      'sortOrder',
+    ];
+    req.query = Object.fromEntries(
+      Object.entries(req.query).filter(([key]) => allowedFields.includes(key))
+    );
+    // Do not allow client to send createdBy. Scoping will be enforced in service layer.
+    next();
+  },
+];
+
 module.exports = {
   validateCreateVoucherAdmin,
   validateCreateVoucherSeller,
   validateUpdateVoucherAdmin,
   validateUpdateVoucherSeller,
   validateGetVouchersAdmin,
+  validateGetVouchersSeller,
 };

--- a/OpenApi/buyer/get-voucher-seller.yaml
+++ b/OpenApi/buyer/get-voucher-seller.yaml
@@ -1,0 +1,255 @@
+openapi: 3.0.0
+info:
+  title: Get Vouchers (Seller)
+  description: API for sellers to get their own vouchers with filter and pagination
+  version: 1.0.0
+
+paths:
+  /buyer/vouchers:
+    get:
+      tags:
+        - Voucher
+      summary: Get vouchers for the current seller (own vouchers only)
+      security:
+        - BearerAuth: []
+      parameters:
+        - in: query
+          name: code
+          schema:
+            type: string
+          description: Filter by voucher code (partial, case-insensitive)
+        - in: query
+          name: status
+          schema:
+            type: string
+            enum: [PENDING, APPROVED, REJECTED]
+          description: Filter by voucher status
+        - in: query
+          name: type
+          schema:
+            type: string
+            enum: [PERCENTAGE, FIXED]
+          description: Filter by voucher type
+        - in: query
+          name: source
+          schema:
+            type: string
+            enum: [SYSTEM, SHOP]
+          description: Filter by voucher source (optional)
+        - in: query
+          name: isActive
+          schema:
+            type: boolean
+          description: Filter by active status
+        - in: query
+          name: isPublic
+          schema:
+            type: boolean
+          description: Filter by public status
+        - in: query
+          name: minOrderValue
+          schema:
+            type: number
+          description: Filter by minOrderValue >= value
+        - in: query
+          name: maxDiscount
+          schema:
+            type: number
+          description: Filter by maximum discount value
+        - in: query
+          name: discountValue
+          schema:
+            type: number
+          description: Filter by discount value
+        - in: query
+          name: quantity
+          schema:
+            type: integer
+          description: Filter by voucher quantity
+        - in: query
+          name: startDate
+          schema:
+            type: string
+            format: date-time
+          description: Filter vouchers with startDate >= this value
+        - in: query
+          name: endDate
+          schema:
+            type: string
+            format: date-time
+          description: Filter vouchers with endDate <= this value
+        - in: query
+          name: page
+          schema:
+            type: integer
+            minimum: 1
+            default: 1
+          description: Page number (default 1)
+        - in: query
+          name: limit
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 100
+            default: 10
+          description: Items per page (default 10, max 100)
+      responses:
+        '200':
+          description: List of vouchers (paginated)
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                    example: success
+                  code:
+                    type: integer
+                    example: 200
+                  message:
+                    type: string
+                    example: Vouchers retrieved successfully
+                  data:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/Voucher'
+                  pagination:
+                    type: object
+                    properties:
+                      page:
+                        type: integer
+                        example: 1
+                      limit:
+                        type: integer
+                        example: 10
+                      total:
+                        type: integer
+                        example: 100
+                      totalPages:
+                        type: integer
+                        example: 10
+        '400':
+          description: Validation error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+components:
+  securitySchemes:
+    BearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+  schemas:
+    Voucher:
+      type: object
+      properties:
+        _id:
+          type: string
+          example: 64e8b7c2f1a2b3c4d5e6f7a8
+        code:
+          type: string
+          example: SUMMER2024
+        type:
+          type: string
+          example: PERCENTAGE
+        discountValue:
+          type: number
+          example: 10
+        maxDiscount:
+          type: number
+          example: 100000
+        minOrderValue:
+          type: number
+          example: 50000
+        applicableSellers:
+          type: array
+          items:
+            type: string
+        applicableUsers:
+          type: array
+          items:
+            type: string
+        applicableProducts:
+          type: array
+          items:
+            type: string
+        applicableCategories:
+          type: array
+          items:
+            type: string
+        startDate:
+          type: string
+          format: date-time
+          example: 2024-06-01T00:00:00.000Z
+        endDate:
+          type: string
+          format: date-time
+          example: 2024-06-30T23:59:59.000Z
+        quantity:
+          type: integer
+          example: 100
+        currentUsage:
+          type: integer
+          example: 10
+        usageLimitPerUser:
+          type: integer
+          example: 1
+        description:
+          type: string
+          example: Summer sale 2024
+        isActive:
+          type: boolean
+          example: true
+        isPublic:
+          type: boolean
+          example: false
+        status:
+          type: string
+          example: APPROVED
+        rejectReason:
+          type: string
+          example: null
+        source:
+          type: string
+          example: SHOP
+        createdBy:
+          type: string
+          example: 64e8b7c2f1a2b3c4d5e6f7a1
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+    ErrorResponse:
+      type: object
+      properties:
+        status:
+          type: string
+          example: error
+        code:
+          type: integer
+          example: 400
+        message:
+          type: string
+          example: Validation failed
+        errors:
+          type: array
+          items:
+            type: object
+            properties:
+              field:
+                type: string
+                example: code
+              message:
+                type: string
+                example: Voucher code must be uppercase. 

--- a/Routes/buyer.route.js
+++ b/Routes/buyer.route.js
@@ -22,6 +22,7 @@ const wardController = require('../Controllers/ward.controller');
 const {
   validateCreateVoucherSeller,
   validateUpdateVoucherSeller,
+  validateGetVouchersSeller,
 } = require('../Middlewares/voucher-validation.middleware');
 const voucherController = require('../Controllers/voucher.controller');
 
@@ -77,6 +78,14 @@ router.patch(
   verifyToken(['SELLER']),
   validateUpdateVoucherSeller,
   voucherController.updateVoucherSeller
+);
+
+// Seller get vouchers (own vouchers only)
+router.get(
+  '/vouchers',
+  verifyToken(['SELLER']),
+  validateGetVouchersSeller,
+  voucherController.getVouchersSeller
 );
 
 module.exports = router;

--- a/Services/voucher.service.js
+++ b/Services/voucher.service.js
@@ -116,6 +116,84 @@ class VoucherService {
     };
     return Voucher.paginate(filter, options);
   }
+
+  /**
+   * Get vouchers for seller (only own vouchers)
+   * @param {Object} query - Query params
+   * @param {string} sellerId - Current seller id
+   * @returns {Promise<Object>} Paginated vouchers
+   */
+  async getVouchersSeller(query, sellerId) {
+    const { page, limit, sortBy, sortOrder } = validationUtils.validatePagination(query);
+
+    const {
+      code,
+      status,
+      type,
+      source,
+      isActive,
+      isPublic,
+      minOrderValue,
+      maxDiscount,
+      discountValue,
+      quantity,
+      startDate,
+      endDate,
+    } = query;
+
+    // Build common filter for both branches
+    const commonFilters = [];
+    if (code) commonFilters.push({ code: { $regex: code, $options: 'i' } });
+    if (status) commonFilters.push({ status });
+    if (type) commonFilters.push({ type });
+    if (isActive !== undefined) commonFilters.push({ isActive });
+    if (isPublic !== undefined) commonFilters.push({ isPublic });
+    if (minOrderValue !== undefined)
+      commonFilters.push({ minOrderValue: { $gte: Number(minOrderValue) } });
+    if (maxDiscount !== undefined) commonFilters.push({ maxDiscount: Number(maxDiscount) });
+    if (discountValue !== undefined) commonFilters.push({ discountValue: Number(discountValue) });
+    if (quantity !== undefined) commonFilters.push({ quantity: Number(quantity) });
+    if (startDate) commonFilters.push({ startDate: { $gte: new Date(startDate) } });
+    if (endDate) commonFilters.push({ endDate: { $lte: new Date(endDate) } });
+
+    // Branch A: seller-owned vouchers (SHOP)
+    const branchShop = {
+      source: 'SHOP',
+      createdBy: sellerId,
+      ...(commonFilters.length ? { $and: commonFilters } : {}),
+    };
+
+    // Branch B: system vouchers applicable to this seller (SYSTEM with applicableSellers contains sellerId)
+    const branchSystem = {
+      source: 'SYSTEM',
+      applicableSellers: { $in: [sellerId] },
+      ...(commonFilters.length ? { $and: commonFilters } : {}),
+    };
+
+    // If client filters source, restrict branches accordingly
+    let orBranches = [];
+    if (source === 'SHOP') orBranches = [branchShop];
+    else if (source === 'SYSTEM') orBranches = [branchSystem];
+    else orBranches = [branchShop, branchSystem];
+
+    const filter = { $or: orBranches };
+
+    const options = {
+      page,
+      limit,
+      sort: { [sortBy]: sortOrder },
+      lean: true,
+      customLabels: {
+        docs: 'data',
+        totalDocs: 'total',
+        totalPages: 'totalPages',
+        page: 'page',
+        limit: 'limit',
+      },
+    };
+
+    return Voucher.paginate(filter, options);
+  }
 }
 
 module.exports = new VoucherService();


### PR DESCRIPTION
### Description

- Link to Jira: https://duongrong2012-1743575833445.atlassian.net/browse/CB-44

---

### Summary

- [x] Implemented GET /seller/vouchers endpoint for sellers to retrieve their vouchers
- [x] Auth & access control: Bearer token required; role SELLER only
- [x] Data scope:
  - Returns seller-owned vouchers: source=SHOP AND createdBy=current seller
  - Returns system vouchers applicable to seller: source=SYSTEM AND applicableSellers contains current seller
  - Optional filter `source` limits results to one branch (SHOP or SYSTEM)
- [x] Supported filters: code, status, type, source, isActive, isPublic, minOrderValue (>=), maxDiscount, discountValue, quantity, startDate (>=), endDate (<=)
- [x] Pagination & sorting handled via validatePagination + mongoose-paginate-v2
- [x] Query validation & sanitization in `validateGetVouchersSeller` (rejects unexpected fields; prevents createdBy injection)
- [x] Standardized response using `response.success` + `response.groupPagination`
- [x] Swagger documentation added at `OpenApi/voucher/get-voucher-seller.yaml` with `BearerAuth`