### PR TITLE
feat(product-model-update):create model update api

### DIFF
--- a/Middlewares/validation.middleware.js
+++ b/Middlewares/validation.middleware.js
@@ -15,6 +15,31 @@ const { v4: uuidv4 } = require('uuid');
 const Media = require('../Models/media.model');
 const { IMAGE_OWNER_TYPE } = require('../Utils/constant');
 const Product = require('../Models/product.model');
+const {
+  validateVariantModelInput,
+  validateVariantImages,
+  validateSkuPayloadUniqueness,
+  checkSkuUniquePerSellerWithModel,
+} = require('../Utils/variant.utils');
+
+// Local helper to map variant-related error messages to standardized field-error objects
+function mapVariantErrors(messages) {
+  const arr = Array.isArray(messages) ? messages : [messages];
+  return arr
+    .filter(m => typeof m === 'string' && m.trim())
+    .map(m => {
+      const lower = m.toLowerCase();
+      let field = 'variantCombinations';
+      if (lower.includes('group')) field = 'variantGroups';
+      if (lower.includes('sku')) field = 'sku';
+      return { field, message: m };
+    });
+}
+
+// Local helper to map express-validator errors to standardized array
+function mapExpressValidatorErrors(result) {
+  return result.array().map(err => ({ field: err.path, message: err.msg }));
+}
 
 /**
  * Middleware to validate user registration fields
@@ -863,7 +888,6 @@ const validateCreateProduct = [
     .optional()
     .isIn(Object.values(PRODUCT_STATUS))
     .withMessage(`Status must be one of: ${Object.values(PRODUCT_STATUS).join(', ')}`),
-  body('metadata').optional().isObject().withMessage('Metadata must be an object'),
   body('totalRating').optional().isNumeric().withMessage('totalRating must be a number'),
   body('totalRatingPoints')
     .optional()
@@ -872,16 +896,9 @@ const validateCreateProduct = [
   body('quantity').optional().isNumeric().withMessage('Quantity must be a number'),
   async (req, res, next) => {
     const errors = validationResult(req);
+    const errorDetails = [];
     if (!errors.isEmpty()) {
-      return next(
-        new AppError(
-          errors
-            .array()
-            .map(e => e.msg)
-            .join(', '),
-          400
-        )
-      );
+      errorDetails.push(...mapExpressValidatorErrors(errors));
     }
     // Filter only allowed fields
     const allowedFields = [
@@ -892,10 +909,11 @@ const validateCreateProduct = [
       'categories',
       'isActive',
       'isFeatured',
-      'metadata',
       'totalRating',
       'totalRatingPoints',
       'quantity',
+      'variantGroups',
+      'variantCombinations',
     ];
 
     // Only admin can set status
@@ -910,27 +928,34 @@ const validateCreateProduct = [
 
     // Required fields
     if (!filteredData.name || !filteredData.description || filteredData.price === undefined) {
-      return next(new AppError('Missing required fields: name, description, price', 400));
+      if (!filteredData.name) errorDetails.push({ field: 'name', message: 'name is required' });
+      if (!filteredData.description)
+        errorDetails.push({ field: 'description', message: 'description is required' });
+      if (filteredData.price === undefined)
+        errorDetails.push({ field: 'price', message: 'price is required' });
     }
 
     // price, discountPrice, quantity, totalRating, totalRatingPoints >= 0
     if (Number(filteredData.price) < 0) {
-      return next(new AppError('Price cannot be negative', 400));
+      errorDetails.push({ field: 'price', message: 'Price cannot be negative' });
     }
     if (filteredData.discountPrice !== undefined && Number(filteredData.discountPrice) < 0) {
-      return next(new AppError('Discount price cannot be negative', 400));
+      errorDetails.push({ field: 'discountPrice', message: 'Discount price cannot be negative' });
     }
     if (filteredData.quantity !== undefined && Number(filteredData.quantity) < 0) {
-      return next(new AppError('Quantity cannot be negative', 400));
+      errorDetails.push({ field: 'quantity', message: 'Quantity cannot be negative' });
     }
     if (filteredData.totalRating !== undefined && Number(filteredData.totalRating) < 0) {
-      return next(new AppError('Total rating cannot be negative', 400));
+      errorDetails.push({ field: 'totalRating', message: 'Total rating cannot be negative' });
     }
     if (
       filteredData.totalRatingPoints !== undefined &&
       Number(filteredData.totalRatingPoints) < 0
     ) {
-      return next(new AppError('Total rating points cannot be negative', 400));
+      errorDetails.push({
+        field: 'totalRatingPoints',
+        message: 'Total rating points cannot be negative',
+      });
     }
     // discountPrice <= price
     if (
@@ -938,21 +963,102 @@ const validateCreateProduct = [
       filteredData.price !== undefined &&
       Number(filteredData.discountPrice) > Number(filteredData.price)
     ) {
-      return next(new AppError('Discount price cannot be greater than price', 400));
+      errorDetails.push({
+        field: 'discountPrice',
+        message: 'Discount price cannot be greater than price',
+      });
     }
-    // Check categories exist and no duplicate
+    // Categories non-DB check (duplicate) only; existence DB check deferred to later
     if (filteredData.categories && filteredData.categories.length > 0) {
-      // Duplicate check
       const uniqueCategories = new Set(filteredData.categories.map(String));
       if (uniqueCategories.size !== filteredData.categories.length) {
-        return next(new AppError('Duplicate category in categories array', 400));
-      }
-      // Existence check
-      const found = await Category.find({ _id: { $in: filteredData.categories } });
-      if (found.length !== filteredData.categories.length) {
-        return next(new AppError('One or more categories do not exist', 400));
+        errorDetails.push({
+          field: 'categories',
+          message: 'Duplicate category in categories array',
+        });
       }
     }
+    // Variant model validation (if provided)
+    if (filteredData.variantGroups || filteredData.variantCombinations) {
+      const {
+        valid,
+        errors: variantErrors,
+        sumQuantity,
+      } = validateVariantModelInput({
+        variantGroups: filteredData.variantGroups,
+        variantCombinations: filteredData.variantCombinations,
+        productQuantity: filteredData.quantity,
+      });
+      if (!valid) {
+        errorDetails.push(...mapVariantErrors(variantErrors));
+      }
+      // Image URL validation for variant combinations (optional field)
+      if (
+        Array.isArray(filteredData.variantCombinations) &&
+        filteredData.variantCombinations.length > 0
+      ) {
+        const { valid: imgValid, errors: imgErrors } = validateVariantImages(
+          filteredData.variantCombinations
+        );
+        if (!imgValid) errorDetails.push(...mapVariantErrors(imgErrors));
+      }
+
+      // SKU validation inside payload (optional SKUs, but if present must be unique within payload)
+      if (
+        Array.isArray(filteredData.variantCombinations) &&
+        filteredData.variantCombinations.length > 0
+      ) {
+        const {
+          valid: skuValid,
+          errors: skuErrors,
+          skus,
+        } = validateSkuPayloadUniqueness(filteredData.variantCombinations);
+        if (!skuValid) errorDetails.push(...mapVariantErrors(skuErrors));
+        // Defer DB SKU check until after non-DB errors have been handled below
+        req.__pendingSkuCheck = { skus };
+      }
+      // Auto-sync product quantity from variant combinations on create when variants are present
+      if (
+        Array.isArray(filteredData.variantGroups) &&
+        filteredData.variantGroups.length > 0 &&
+        Array.isArray(filteredData.variantCombinations) &&
+        filteredData.variantCombinations.length > 0
+      ) {
+        filteredData.quantity = sumQuantity;
+      }
+    }
+    if (errorDetails.length > 0) {
+      return next(new AppError('Validation failed', 400, errorDetails));
+    }
+
+    // DB checks (only when all non-DB validations passed)
+    // 1) Categories existence
+    if (filteredData.categories && filteredData.categories.length > 0) {
+      const found = await Category.find({ _id: { $in: filteredData.categories } });
+      if (found.length !== filteredData.categories.length) {
+        return next(
+          new AppError('Validation failed', 400, [
+            { field: 'categories', message: 'One or more categories do not exist' },
+          ])
+        );
+      }
+    }
+    // 2) SKU unique per seller
+    if (req.__pendingSkuCheck && Array.isArray(req.__pendingSkuCheck.skus)) {
+      const { skus } = req.__pendingSkuCheck;
+      const { ok } = await checkSkuUniquePerSellerWithModel(
+        Product,
+        req.user?._id || filteredData.createdBy,
+        skus
+      );
+      if (!ok)
+        return next(
+          new AppError('Validation failed', 400, [
+            { field: 'sku', message: 'SKU must be unique per seller' },
+          ])
+        );
+    }
+
     req.validatedData = filteredData;
     next();
   },
@@ -1115,23 +1221,14 @@ const validateUpdateProduct = [
     .isLength({ min: 1, max: 500 })
     .withMessage('Rejected reason must be 1-500 characters'),
 
-  body('metadata').optional().isObject().withMessage('Metadata must be an object'),
-
   body('quantity').optional().isNumeric().withMessage('Quantity must be a number'),
 
   async (req, res, next) => {
     try {
       const errors = validationResult(req);
+      const errorDetails = [];
       if (!errors.isEmpty()) {
-        return next(
-          new AppError(
-            errors
-              .array()
-              .map(e => e.msg)
-              .join(', '),
-            400
-          )
-        );
+        errorDetails.push(...mapExpressValidatorErrors(errors));
       }
 
       // Filter only allowed fields based on user role
@@ -1145,6 +1242,8 @@ const validateUpdateProduct = [
         'isFeatured',
         'metadata',
         'quantity',
+        'variantGroups',
+        'variantCombinations',
       ];
 
       // Only admin can update status and rejectedReason
@@ -1160,20 +1259,20 @@ const validateUpdateProduct = [
         }
       }
 
-      // Check if there are any fields to update
+      // Check if there are any fields to update (non-DB)
       if (Object.keys(filteredData).length === 0) {
-        return next(new AppError('No fields provided for update', 400));
+        errorDetails.push({ field: 'general', message: 'No fields provided for update' });
       }
 
-      // Business validation: price, discountPrice, quantity >= 0
+      // Business validation: price, discountPrice, quantity >= 0 (non-DB)
       if (filteredData.price !== undefined && Number(filteredData.price) < 0) {
-        return next(new AppError('Price cannot be negative', 400));
+        errorDetails.push({ field: 'price', message: 'Price cannot be negative' });
       }
       if (filteredData.discountPrice !== undefined && Number(filteredData.discountPrice) < 0) {
-        return next(new AppError('Discount price cannot be negative', 400));
+        errorDetails.push({ field: 'discountPrice', message: 'Discount price cannot be negative' });
       }
       if (filteredData.quantity !== undefined && Number(filteredData.quantity) < 0) {
-        return next(new AppError('Quantity cannot be negative', 400));
+        errorDetails.push({ field: 'quantity', message: 'Quantity cannot be negative' });
       }
 
       // Business validation: discountPrice <= price
@@ -1182,12 +1281,18 @@ const validateUpdateProduct = [
         filteredData.price !== undefined &&
         Number(filteredData.discountPrice) > Number(filteredData.price)
       ) {
-        return next(new AppError('Discount price cannot be greater than price', 400));
+        errorDetails.push({
+          field: 'discountPrice',
+          message: 'Discount price cannot be greater than price',
+        });
       }
 
       // Business validation: rejectedReason required when status is REJECTED
       if (filteredData.status === PRODUCT_STATUS.REJECTED && !filteredData.rejectedReason) {
-        return next(new AppError('Rejected reason is required when status is REJECTED', 400));
+        errorDetails.push({
+          field: 'rejectedReason',
+          message: 'Rejected reason is required when status is REJECTED',
+        });
       }
 
       // Business validation: Check categories exist and no duplicate
@@ -1201,16 +1306,33 @@ const validateUpdateProduct = [
         // Duplicate check
         const uniqueCategories = new Set(categories.map(String));
         if (uniqueCategories.size !== categories.length) {
-          return next(new AppError('Duplicate category in categories array', 400));
+          errorDetails.push({
+            field: 'categories',
+            message: 'Duplicate category in categories array',
+          });
         }
 
         // Existence check
+        // Before DB check, return non-DB errors if any
+        if (errorDetails.length > 0) {
+          return next(new AppError('Validation failed', 400, errorDetails));
+        }
+
         const found = await Category.find({ _id: { $in: categories } });
         if (found.length !== categories.length) {
-          return next(new AppError('One or more categories do not exist', 400));
+          return next(
+            new AppError('Validation failed', 400, [
+              { field: 'categories', message: 'One or more categories do not exist' },
+            ])
+          );
         }
 
         filteredData.categories = categories;
+      }
+
+      // If any non-DB errors collected so far, return once
+      if (errorDetails.length > 0) {
+        return next(new AppError('Validation failed', 400, errorDetails));
       }
 
       // Business validation: Check product exists
@@ -1221,7 +1343,11 @@ const validateUpdateProduct = [
 
       // Business validation: Check user permissions
       if (user.role === USER_ROLES.SELLER && product.createdBy.toString() !== user._id.toString()) {
-        return next(new AppError('You can only update your own products', 403));
+        return next(
+          new AppError('Validation failed', 403, [
+            { field: 'permission', message: 'You can only update your own products' },
+          ])
+        );
       }
 
       // Auto-set status to PENDING when seller updates product (except when admin is updating)
@@ -1229,6 +1355,81 @@ const validateUpdateProduct = [
         filteredData.status = PRODUCT_STATUS.PENDING;
         // Clear rejectedReason when status changes to PENDING
         filteredData.rejectedReason = null;
+      }
+
+      // Variant model validation (when updating) + rules for quantity edits
+      const willHaveVariants =
+        (filteredData.variantGroups !== undefined
+          ? Array.isArray(filteredData.variantGroups) && filteredData.variantGroups.length > 0
+          : Array.isArray(product.variantGroups) && product.variantGroups.length > 0) ||
+        (filteredData.variantCombinations !== undefined
+          ? Array.isArray(filteredData.variantCombinations) &&
+            filteredData.variantCombinations.length > 0
+          : Array.isArray(product.variantCombinations) && product.variantCombinations.length > 0);
+
+      if (
+        filteredData.variantGroups !== undefined ||
+        filteredData.variantCombinations !== undefined ||
+        filteredData.quantity !== undefined
+      ) {
+        const effective = {
+          variantGroups:
+            filteredData.variantGroups !== undefined
+              ? filteredData.variantGroups
+              : product.variantGroups,
+          variantCombinations:
+            filteredData.variantCombinations !== undefined
+              ? filteredData.variantCombinations
+              : product.variantCombinations,
+          productQuantity:
+            filteredData.quantity !== undefined ? filteredData.quantity : product.quantity,
+        };
+        const { valid, errors: variantErrors, sumQuantity } = validateVariantModelInput(effective);
+        if (!valid) {
+          return next(new AppError('Validation failed', 400, mapVariantErrors(variantErrors)));
+        }
+        // Image URL validation for update payload if variantCombinations provided
+        if (
+          Array.isArray(effective.variantCombinations) &&
+          effective.variantCombinations.length > 0
+        ) {
+          const { valid: imgValid, errors: imgErrors } = validateVariantImages(
+            effective.variantCombinations
+          );
+          if (!imgValid)
+            return next(new AppError('Validation failed', 400, mapVariantErrors(imgErrors)));
+        }
+
+        // SKU validation for update payload if variantCombinations provided
+        if (
+          Array.isArray(effective.variantCombinations) &&
+          effective.variantCombinations.length > 0
+        ) {
+          const {
+            valid: skuValid,
+            errors: skuErrors,
+            skus,
+          } = validateSkuPayloadUniqueness(effective.variantCombinations);
+          if (!skuValid)
+            return next(new AppError('Validation failed', 400, mapVariantErrors(skuErrors)));
+          const { ok } = await checkSkuUniquePerSellerWithModel(
+            Product,
+            product.createdBy,
+            skus,
+            product._id
+          );
+          if (!ok)
+            return next(
+              new AppError('Validation failed', 400, [
+                { field: 'sku', message: 'SKU must be unique per seller' },
+              ])
+            );
+        }
+        if (willHaveVariants) {
+          // Disallow direct quantity override; always sync from combinations
+          if (filteredData.quantity !== undefined) delete filteredData.quantity;
+          filteredData.quantity = sumQuantity;
+        }
       }
 
       // Store validated data and product for controller usage

--- a/Models/product.model.js
+++ b/Models/product.model.js
@@ -2,6 +2,11 @@ const mongoose = require('mongoose');
 const slugify = require('slugify');
 const { v4: uuidv4 } = require('uuid');
 const { PRODUCT_STATUS } = require('../Utils/constant');
+const {
+  validateVariantModelInput,
+  validateSkuPayloadUniqueness,
+  checkSkuUniquePerSellerWithModel,
+} = require('../Utils/variant.utils');
 
 /**
  * Product Schema
@@ -53,9 +58,6 @@ const ProductSchema = new mongoose.Schema(
       type: String,
       trim: true,
     },
-    metadata: {
-      type: mongoose.Schema.Types.Mixed, // Dynamic attributes like size, color, brand, etc.
-    },
     totalRating: {
       type: Number,
       default: 0,
@@ -72,6 +74,41 @@ const ProductSchema = new mongoose.Schema(
       type: Number,
       default: 0,
     },
+    // Variant system
+    // Define variant groups (e.g., Size, Color, RAM). Each group has a name and allowed option values.
+    variantGroups: [
+      {
+        name: { type: String, required: true, trim: true },
+        options: [
+          {
+            value: { type: String, required: true, trim: true },
+          },
+        ],
+      },
+    ],
+    // Enumerate valid variant combinations. Each combination must include one option per group.
+    // Used to control inventory per combination and explicit price overrides.
+    variantCombinations: [
+      {
+        // Array of { groupName, optionValue } sized exactly as variantGroups length
+        options: [
+          {
+            groupName: { type: String, required: true, trim: true },
+            optionValue: { type: String, required: true, trim: true },
+          },
+        ],
+        // Quantity available for this specific combination
+        quantity: { type: Number, required: true, min: 0 },
+        // Explicit price for this combination (required)
+        price: { type: Number, required: true, min: 0 },
+        // Optional discount price for this combination (must be <= price when provided)
+        discountPrice: { type: Number },
+        // Optional image URL for this specific variant combination
+        image: { type: String, trim: true },
+        // Optional SKU for inventory; uppercase automatically; unique per seller is validated in pre-save
+        sku: { type: String, uppercase: true, trim: true },
+      },
+    ],
     createdBy: {
       type: mongoose.Schema.Types.ObjectId,
       ref: 'User',
@@ -86,7 +123,7 @@ const ProductSchema = new mongoose.Schema(
 /**
  * Pre-save hook to auto-generate slug from name and uuid if not provided
  */
-ProductSchema.pre('save', function (next) {
+ProductSchema.pre('save', async function (next) {
   if (this.isModified('name')) {
     const baseSlug = slugify(this.name, {
       lower: true,
@@ -94,6 +131,36 @@ ProductSchema.pre('save', function (next) {
       locale: 'vi',
     });
     this.slug = `${baseSlug}-${uuidv4().slice(0, 8)}`;
+  }
+  // Validate variant combinations consistency using shared helper to avoid duplication
+  if (
+    this.isNew ||
+    this.isModified('variantGroups') ||
+    this.isModified('variantCombinations') ||
+    this.isModified('quantity')
+  ) {
+    const { valid, errors } = validateVariantModelInput({
+      variantGroups: this.variantGroups,
+      variantCombinations: this.variantCombinations,
+      productQuantity: this.quantity,
+    });
+    if (!valid) {
+      return next(new Error(errors.join('; ')));
+    }
+    // Enforce SKU rules using utils
+    const combos = Array.isArray(this.variantCombinations) ? this.variantCombinations : [];
+    const { valid: skuValid, errors: skuErrors, skus } = validateSkuPayloadUniqueness(combos);
+    if (!skuValid) return next(new Error(skuErrors.join('; ')));
+    // Check uniqueness per seller (across all products of the same creator)
+    if (skus.length > 0) {
+      const { ok } = await checkSkuUniquePerSellerWithModel(
+        this.constructor,
+        this.createdBy,
+        skus,
+        this._id
+      );
+      if (!ok) return next(new Error('SKU must be unique per seller'));
+    }
   }
   next();
 });

--- a/OpenApi/buyer/get-bookmarks.yaml
+++ b/OpenApi/buyer/get-bookmarks.yaml
@@ -89,10 +89,7 @@ paths:
                           quantity: 10
                           createdBy: "65f1a2b3c4d5e6f7g8h9i0j3"
                           slug: "iphone-15-pro-a1b2c3d4"
-                          metadata:
-                            brand: "Apple"
-                            color: "Titanium"
-                            storage: "256GB"
+                          # metadata removed
                           createdAt: "2024-01-15T10:30:00.000Z"
                           updatedAt: "2024-01-15T10:30:00.000Z"
                         - _id: "65f1a2b3c4d5e6f7g8h9i0j4"
@@ -110,11 +107,7 @@ paths:
                           quantity: 5
                           createdBy: "65f1a2b3c4d5e6f7g8h9i0j6"
                           slug: "macbook-pro-m3-e5f6g7h8"
-                          metadata:
-                            brand: "Apple"
-                            color: "Space Gray"
-                            storage: "512GB"
-                            processor: "M3 Pro"
+                          # metadata removed
                           createdAt: "2024-01-14T15:45:00.000Z"
                           updatedAt: "2024-01-14T15:45:00.000Z"
                       pagination:

--- a/OpenApi/product/create-product.yaml
+++ b/OpenApi/product/create-product.yaml
@@ -65,13 +65,6 @@ paths:
                   enum: [PENDING, APPROVED, REJECTED]
                   description: Product status (Admin only, default is PENDING)
                   example: "PENDING"
-                metadata:
-                  type: object
-                  description: Dynamic attributes (size, color, brand, etc.)
-                  example:
-                    size: ["S", "M", "L"]
-                    color: ["Red", "Blue"]
-                    brand: "Nike"
                 totalRating:
                   type: number
                   minimum: 0
@@ -87,6 +80,122 @@ paths:
                   minimum: 0
                   description: Product stock quantity (>= 0)
                   example: 100
+                variantGroups:
+                  type: array
+                  description: Variant groups definition (required if variantCombinations provided)
+                  items:
+                    type: object
+                    properties:
+                      name:
+                        type: string
+                        example: "Size"
+                      options:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            value:
+                              type: string
+                              example: "L"
+                            # priceDelta removed
+                variantCombinations:
+                  type: array
+                  description: Enumerated valid combinations. Sum of quantities must equal product quantity
+                  items:
+                    type: object
+                    properties:
+                      _id:
+                        type: string
+                        description: MongoDB generated id (returned after create)
+                        readOnly: true
+                      options:
+                        type: array
+                        description: One option per group (must match variantGroups)
+                        items:
+                          type: object
+                          properties:
+                            groupName:
+                              type: string
+                              example: "Size"
+                            optionValue:
+                              type: string
+                              example: "L"
+                      quantity:
+                        type: number
+                        minimum: 0
+                        example: 10
+                      price:
+                        type: number
+                        minimum: 0
+                        description: Price for this specific variant combination (required)
+                        example: 360000
+                      image:
+                        type: string
+                        description: Image URL representing this variant combination
+                        example: "https://cdn.example.com/products/hoodie/XL-GRAY.png"
+                      sku:
+                        type: string
+                        description: Optional seller SKU (will be uppercased, unique per seller)
+                        example: "HD-L-GRAY-001"
+                      discountPrice:
+                        type: number
+                        minimum: 0
+                        description: Optional discounted price for this combination (must be <= price)
+                        example: 315000
+            examples:
+              no_variants:
+                summary: Create product without variants
+                value:
+                  name: "Basic T-Shirt"
+                  description: "Soft cotton T-shirt"
+                  price: 120000
+                  discountPrice: 99000
+                  categories: ["65f1a2b3c4d5e6f7g8h9i0j1"]
+                  isActive: true
+                  isFeatured: false
+                  quantity: 150
+              with_variants:
+                summary: Create product with variant groups and combinations
+                value:
+                  name: "Premium Hoodie"
+                  description: "Fleece-lined hoodie"
+                  price: 350000
+                  discountPrice: 320000
+                  categories: ["65f1a2b3c4d5e6f7g8h9i0j1"]
+                  variantGroups:
+                    - name: "Size"
+                      options:
+                        - value: "S"
+                        - value: "M"
+                        - value: "L"
+                    - name: "Color"
+                      options:
+                        - value: "Black"
+                        - value: "Gray"
+                  variantCombinations:
+                    - sku: "HD-S-BLACK-001"
+                      options:
+                        - { groupName: "Size", optionValue: "S" }
+                        - { groupName: "Color", optionValue: "Black" }
+                      quantity: 5
+                      price: 330000
+                      discountPrice: 299000
+                      image: "https://cdn.example.com/hoodie/S-BLACK.png"
+                    - sku: "HD-M-BLACK-001"
+                      options:
+                        - { groupName: "Size", optionValue: "M" }
+                        - { groupName: "Color", optionValue: "Black" }
+                      quantity: 8
+                      price: 340000
+                      image: "https://cdn.example.com/hoodie/M-BLACK.png"
+                    - sku: "HD-L-GRAY-001"
+                      options:
+                        - { groupName: "Size", optionValue: "L" }
+                        - { groupName: "Color", optionValue: "Gray" }
+                      quantity: 12
+                      price: 360000
+                      discountPrice: 315000
+                      image: "https://cdn.example.com/hoodie/L-GRAY.png"
       responses:
         '200':
           description: Product created successfully
@@ -163,12 +272,7 @@ components:
           type: string
           enum: [PENDING, APPROVED, REJECTED]
           example: "PENDING"
-        metadata:
-          type: object
-          example:
-            size: ["S", "M", "L"]
-            color: ["Red", "Blue"]
-            brand: "Nike"
+        # metadata removed
         totalRating:
           type: number
           example: 0

--- a/OpenApi/product/get-product-detail.yaml
+++ b/OpenApi/product/get-product-detail.yaml
@@ -127,12 +127,7 @@ components:
         rejectedReason:
           type: string
           example: null
-        metadata:
-          type: object
-          example:
-            brand: "Apple"
-            color: "Titanium"
-            storage: "256GB"
+        # metadata removed
         totalRating:
           type: number
           example: 4.5

--- a/OpenApi/product/get-product.yaml
+++ b/OpenApi/product/get-product.yaml
@@ -239,10 +239,7 @@ components:
         isFeatured:
           type: boolean
           example: false
-        metadata:
-          type: object
-          additionalProperties: true
-          example: { color: 'black', brand: 'Dell', size: '13 inch' }
+        # metadata removed
         totalRating:
           type: number
           example: 4.5

--- a/OpenApi/product/update-product.yaml
+++ b/OpenApi/product/update-product.yaml
@@ -82,18 +82,61 @@ paths:
                   maxLength: 500
                   description: Reason for rejection (Admin only, required when status is REJECTED)
                   example: "Product description violates community guidelines"
-                metadata:
-                  type: object
-                  description: Additional product attributes
-                  example:
-                    size: "L"
-                    color: "Blue"
-                    brand: "Nike"
+                # metadata removed
                 quantity:
                   type: number
                   minimum: 0
                   description: Available quantity
                   example: 50
+                variantGroups:
+                  type: array
+                  description: Variant groups definition (optional; required if variantCombinations provided)
+                  items:
+                    type: object
+                    properties:
+                      name:
+                        type: string
+                      options:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            value:
+                              type: string
+                            # priceDelta removed
+                variantCombinations:
+                  type: array
+                  description: Valid combinations; sum of quantities must equal product quantity
+                  items:
+                    type: object
+                    properties:
+                      _id:
+                        type: string
+                      options:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            groupName:
+                              type: string
+                            optionValue:
+                              type: string
+                      quantity:
+                        type: number
+                        minimum: 0
+                      price:
+                        type: number
+                        minimum: 0
+                      discountPrice:
+                        type: number
+                        minimum: 0
+                      image:
+                        type: string
+                        description: Image URL representing this variant combination
+                      sku:
+                        type: string
+                        description: Optional seller SKU (uppercased on save, must be unique per seller)
+                        example: "HD-L-GRAY-001"
             examples:
               admin_update:
                 summary: Admin updating product status
@@ -108,6 +151,106 @@ paths:
                   price: 99.99
                   discountPrice: 79.99
                   quantity: 50
+              full_update_with_variants:
+                summary: Admin updates most fields including variants and SKUs
+                value:
+                  name: "Hoodie 2.0"
+                  description: "Premium fleece hoodie with better zipper"
+                  isActive: true
+                  isFeatured: true
+                  status: "APPROVED"
+                  categories: ["64b8a8f12a3c1f5d6e9a0001", "64b8a8f12a3c1f5d6e9a0002"]
+                  variantGroups:
+                    - name: "Size"
+                      options:
+                        - value: "M"
+                        - value: "L"
+                        - value: "XL"
+                    - name: "Color"
+                      options:
+                        - value: "BLACK"
+                        - value: "GRAY"
+                  variantCombinations:
+                    - _id: "64c1a7f12a3c1f5d6e9a1001"  # existing combination to update
+                      options:
+                        - groupName: "Size"
+                          optionValue: "L"
+                        - groupName: "Color"
+                          optionValue: "BLACK"
+                      quantity: 20
+                      price: 42.5
+                      discountPrice: 39.9
+                      image: "https://cdn.example.com/hoodie2/L-BLACK.png"
+                      sku: "HD-L-BLACK-001"
+                    - _id: "64c1a7f12a3c1f5d6e9a1002"  # existing combination to update
+                      options:
+                        - groupName: "Size"
+                          optionValue: "M"
+                        - groupName: "Color"
+                          optionValue: "GRAY"
+                      quantity: 15
+                      price: 40
+                      discountPrice: 0
+                      image: "https://cdn.example.com/hoodie2/M-GRAY.png"
+                      sku: "HD-M-GRAY-002"
+                    - options:  # new combination without _id (will be created)
+                        - groupName: "Size"
+                          optionValue: "XL"
+                        - groupName: "Color"
+                          optionValue: "GRAY"
+                      quantity: 10
+                      price: 45
+                      discountPrice: 41
+                      image: "https://cdn.example.com/hoodie2/XL-GRAY.png"
+                      sku: "HD-XL-GRAY-003"
+              partial_update_some_fields:
+                summary: Seller updates a few simple fields (no variants touched)
+                value:
+                  name: "Basic Tee - New Title"
+                  description: "Short description updated"
+                  isFeatured: false
+                  isActive: true
+              variants_add_and_update:
+                summary: Seller updates quantities and prices for existing variants and adds one new
+                value:
+                  variantCombinations:
+                    - _id: "64c1a7f12a3c1f5d6e9a2001"
+                      options:
+                        - groupName: "Size"
+                          optionValue: "M"
+                        - groupName: "Color"
+                          optionValue: "RED"
+                      quantity: 12
+                      price: 19.9
+                      discountPrice: 17.9
+                      image: "https://cdn.example.com/tee/M-RED.png"
+                      sku: "TEE-M-RED-001"
+                    - _id: "64c1a7f12a3c1f5d6e9a2002"
+                      options:
+                        - groupName: "Size"
+                          optionValue: "L"
+                        - groupName: "Color"
+                          optionValue: "RED"
+                      quantity: 8
+                      price: 21.9
+                      discountPrice: 0
+                      image: "https://cdn.example.com/tee/L-RED.png"
+                      sku: "TEE-L-RED-002"
+                    - options:  # add a new variant
+                        - groupName: "Size"
+                          optionValue: "XL"
+                        - groupName: "Color"
+                          optionValue: "RED"
+                      quantity: 5
+                      price: 22.9
+                      discountPrice: 20.9
+                      image: "https://cdn.example.com/tee/XL-RED.png"
+                      sku: "TEE-XL-RED-003"
+              admin_reject_with_reason:
+                summary: Admin rejects product with a reason
+                value:
+                  status: "REJECTED"
+                  rejectedReason: "Insufficient specification details provided"
       responses:
         '200':
           description: Product updated successfully

--- a/OpenApi/upload/upload-product-image.yaml
+++ b/OpenApi/upload/upload-product-image.yaml
@@ -92,12 +92,7 @@ paths:
                           isFeatured:
                             type: boolean
                             example: false
-                          metadata:
-                            type: object
-                            example:
-                              size: ["S", "M", "L"]
-                              color: ["Red", "Blue"]
-                              brand: "Apple"
+                          # metadata removed
                           totalRating:
                             type: number
                             example: 100
@@ -159,10 +154,7 @@ paths:
                         categories: ["65f1a2b3c4d5e6f7g8h9i0j4"]
                         isActive: true
                         isFeatured: false
-                        metadata:
-                          size: ["S", "M", "L"]
-                          color: ["Red", "Blue"]
-                          brand: "Apple"
+                        # metadata removed
                         totalRating: 100
                         totalRatingPoints: 450
                         quantity: 50
@@ -190,10 +182,7 @@ paths:
                         categories: ["65f1a2b3c4d5e6f7g8h9i0j4"]
                         isActive: true
                         isFeatured: false
-                        metadata:
-                          size: ["S", "M", "L"]
-                          color: ["Red", "Blue"]
-                          brand: "Apple"
+                        # metadata removed
                         totalRating: 100
                         totalRatingPoints: 450
                         quantity: 50

--- a/README.md
+++ b/README.md
@@ -78,6 +78,23 @@ Notes:
 - Safe to run multiple times; only updates vouchers without a `target` field
 - Requires a valid `MONGO_URI` in your `.env`
 
+### Initialize Empty Variant Fields for Legacy Products
+
+If you recently added variant support (`variantGroups`, `variantCombinations`) to the Product model and need to initialize existing documents, run:
+
+```bash
+npm run seed:product-variants-empty
+```
+
+This command executes `seeders/update-product-variants-empty.js`, which:
+- Finds products where `variantGroups`/`variantCombinations` are missing or not arrays
+- Sets both fields to empty arrays: `variantGroups: []`, `variantCombinations: []`
+- Prints how many documents were modified
+
+Notes:
+- Safe to run multiple times; only updates documents that need fixing
+- Requires `MONGO_URI` configured in `.env`
+
 ## Province Seeder
 
 This project includes a seeder script to import all provinces from `province.json` into the MongoDB `provinces` collection.

--- a/Utils/variant.utils.js
+++ b/Utils/variant.utils.js
@@ -1,0 +1,307 @@
+/**
+ * Variant utilities
+ * Centralizes validation and resolution logic for product variants
+ */
+const { SUPPORTED_FILE_TYPES } = require('./constant');
+
+/**
+ * Check if product has variants
+ * @param {any} product
+ */
+function hasVariants(product) {
+  return Array.isArray(product?.variantGroups) && product.variantGroups.length > 0;
+}
+
+/**
+ * Validate variant groups and combinations against product quantity.
+ * - Each combination must include exactly one option per group
+ * - Option values must exist in respective group
+ * - Sum of combination quantities must equal product quantity
+ * @param {{variantGroups?: any[], variantCombinations?: any[], productQuantity?: number}} input
+ * @returns {{ valid: boolean, errors: string[], sumQuantity: number }}
+ */
+function validateVariantModelInput(input) {
+  const groups = Array.isArray(input.variantGroups) ? input.variantGroups : [];
+  const combos = Array.isArray(input.variantCombinations) ? input.variantCombinations : [];
+  const errors = [];
+
+  if (groups.length === 0 && combos.length === 0) {
+    return { valid: true, errors, sumQuantity: 0 };
+  }
+  if (groups.length === 0 && combos.length > 0) {
+    errors.push('variantCombinations requires variantGroups to be defined');
+    return { valid: false, errors, sumQuantity: 0 };
+  }
+  if (groups.length > 0 && combos.length === 0) {
+    errors.push('variantGroups requires variantCombinations to be defined');
+    return { valid: false, errors, sumQuantity: 0 };
+  }
+
+  // Validate groups uniqueness and options uniqueness per group
+  const groupNames = new Set();
+  for (const g of groups) {
+    if (!g || typeof g.name !== 'string' || !g.name.trim()) {
+      errors.push('Each variant group must have a non-empty name');
+      continue;
+    }
+    if (groupNames.has(g.name)) errors.push(`Duplicate variant group: ${g.name}`);
+    groupNames.add(g.name);
+    const seenOpts = new Set();
+    const opts = Array.isArray(g.options) ? g.options : [];
+    for (const o of opts) {
+      if (!o || typeof o.value !== 'string' || !o.value.trim()) {
+        errors.push(`Group ${g.name}: option value must be non-empty string`);
+        continue;
+      }
+      if (seenOpts.has(o.value)) errors.push(`Group ${g.name}: duplicate option ${o.value}`);
+      seenOpts.add(o.value);
+    }
+  }
+
+  // Validate combinations
+  for (const c of combos) {
+    const opts = Array.isArray(c.options) ? c.options : [];
+    if (opts.length !== groups.length) {
+      errors.push('Each variant combination must include exactly one option per variant group');
+      continue;
+    }
+    // Require price and validate discountPrice
+    if (typeof c.price !== 'number' || c.price < 0) {
+      errors.push('Each variant combination must have a non-negative price');
+    }
+    if (c.discountPrice !== undefined && c.discountPrice !== null) {
+      if (typeof c.discountPrice !== 'number' || c.discountPrice < 0) {
+        errors.push(
+          'variant combination discountPrice must be a non-negative number when provided'
+        );
+      } else if (typeof c.price === 'number' && c.discountPrice > c.price) {
+        errors.push('variant combination discountPrice cannot be greater than price');
+      }
+    }
+    for (const g of groups) {
+      const matched = opts.find(o => o.groupName === g.name);
+      if (!matched) {
+        errors.push(`Combination missing option for group: ${g.name}`);
+        continue;
+      }
+      const exists = Array.isArray(g.options)
+        ? g.options.some(o => o.value === matched.optionValue)
+        : false;
+      if (!exists) errors.push(`Invalid option ${matched.optionValue} for group ${g.name}`);
+    }
+  }
+  // Ensure unique options combination (avoid duplicate same options set)
+  const optionsKeySet = new Set();
+  for (const c of combos) {
+    const key = (Array.isArray(c.options) ? c.options : [])
+      .slice()
+      .sort((a, b) => a.groupName.localeCompare(b.groupName))
+      .map(o => `${o.groupName}=${o.optionValue}`)
+      .join('|');
+    if (optionsKeySet.has(key)) errors.push(`Duplicate variant combination options: ${key}`);
+    optionsKeySet.add(key);
+  }
+
+  const sumQuantity = combos.reduce((s, c) => s + (Number(c.quantity) || 0), 0);
+  if (input.productQuantity === undefined || input.productQuantity === null) {
+    // We cannot fully validate equality without product quantity
+    return { valid: errors.length === 0, errors, sumQuantity };
+  }
+
+  if (sumQuantity !== Number(input.productQuantity)) {
+    errors.push('Sum of variant combination quantities must equal product quantity');
+  }
+  return { valid: errors.length === 0, errors, sumQuantity };
+}
+
+/**
+ * Validate image URLs for variant combinations (optional field)
+ * Rules:
+ * - If provided: must be a non-empty string
+ * - Must be a valid http/https URL
+ * - Path must end with an allowed image extension (per SUPPORTED_FILE_TYPES)
+ * @param {Array<any>} variantCombinations
+ * @returns {{ valid: boolean, errors: string[] }}
+ */
+function validateVariantImages(variantCombinations) {
+  const combos = Array.isArray(variantCombinations) ? variantCombinations : [];
+  const errors = [];
+  const allowedExts = Array.isArray(SUPPORTED_FILE_TYPES?.IMAGE?.EXTENSIONS)
+    ? SUPPORTED_FILE_TYPES.IMAGE.EXTENSIONS.map(e => e.toLowerCase())
+    : ['.jpg', '.jpeg', '.png', '.webp'];
+
+  for (const c of combos) {
+    const img = c?.image;
+    if (img === undefined || img === null) continue; // optional
+    if (typeof img !== 'string' || !img.trim()) {
+      errors.push('variant combination image must be a non-empty string when provided');
+      continue;
+    }
+    const s = img.trim();
+    let urlObj;
+    try {
+      urlObj = new URL(s);
+    } catch {
+      errors.push('variant combination image must be a valid URL');
+      continue;
+    }
+    if (!['http:', 'https:'].includes(urlObj.protocol)) {
+      errors.push('variant combination image must use http or https');
+    }
+    const pathname = (urlObj.pathname || '').toLowerCase();
+    if (!allowedExts.some(ext => pathname.endsWith(ext))) {
+      errors.push(
+        'variant combination image must have a valid image extension (.jpg, .jpeg, .png, .webp)'
+      );
+    }
+  }
+  return { valid: errors.length === 0, errors };
+}
+
+/**
+ * Normalize SKU to uppercase trimmed; return null if empty/invalid
+ * @param {any} value
+ * @returns {string|null}
+ */
+function normalizeSku(value) {
+  if (typeof value !== 'string') return null;
+  const t = value.trim();
+  if (!t) return null;
+  return t.toUpperCase();
+}
+
+/**
+ * Extract normalized SKUs from variantCombinations
+ * @param {Array<any>} variantCombinations
+ * @returns {string[]} normalized non-empty SKUs
+ */
+function extractSkus(variantCombinations) {
+  const combos = Array.isArray(variantCombinations) ? variantCombinations : [];
+  return combos.map(c => normalizeSku(c?.sku)).filter(s => typeof s === 'string' && s.length > 0);
+}
+
+/**
+ * Validate SKU uniqueness within a single product payload. Does NOT check DB.
+ * @param {Array<any>} variantCombinations
+ * @returns {{ valid: boolean, errors: string[], skus: string[] }}
+ */
+function validateSkuPayloadUniqueness(variantCombinations) {
+  const errors = [];
+  const skus = extractSkus(variantCombinations);
+  const seen = new Set();
+  for (const s of skus) {
+    if (seen.has(s)) {
+      errors.push(`Duplicate SKU within product: ${s}`);
+    } else {
+      seen.add(s);
+    }
+  }
+  return { valid: errors.length === 0, errors, skus };
+}
+
+/**
+ * Resolve variant selection for an order item.
+ * @param {any} product - product document (lean)
+ * @param {{ _id?: string, options?: Array<{groupName:string, optionValue:string}> }} variant
+ * @returns {{ combination: any, optionsSnapshot: Array<{groupName:string, optionValue:string}> }}
+ */
+function resolveVariantSelection(product, variant) {
+  if (!hasVariants(product)) {
+    if (variant) throw new Error('Product has no variants');
+    return { combination: null, optionsSnapshot: undefined };
+  }
+  if (!variant || typeof variant !== 'object') {
+    throw new Error('Variant selection is required');
+  }
+  const combos = Array.isArray(product.variantCombinations) ? product.variantCombinations : [];
+  let chosen = null;
+  if (variant._id) {
+    chosen = combos.find(c => String(c._id) === String(variant._id));
+    if (!chosen) throw new Error('Invalid variant combination _id');
+  } else if (Array.isArray(variant.options)) {
+    const groups = Array.isArray(product.variantGroups) ? product.variantGroups : [];
+    if (variant.options.length !== groups.length) {
+      throw new Error('Variant options must include one value per group');
+    }
+    const normalized = groups.map(group => {
+      const opt = variant.options.find(o => o.groupName === group.name);
+      if (!opt) throw new Error(`Missing variant for group ${group.name}`);
+      const exists = Array.isArray(group.options)
+        ? group.options.some(g => g.value === opt.optionValue)
+        : false;
+      if (!exists) throw new Error(`Invalid option ${opt.optionValue} for group ${group.name}`);
+      return { groupName: group.name, optionValue: opt.optionValue };
+    });
+    chosen = combos.find(c => {
+      const opts = Array.isArray(c.options) ? c.options : [];
+      if (opts.length !== normalized.length) return false;
+      return normalized.every(n =>
+        opts.some(o => o.groupName === n.groupName && o.optionValue === n.optionValue)
+      );
+    });
+    if (!chosen) throw new Error('Variant option combination is not available');
+  } else {
+    throw new Error('Variant must include _id or options');
+  }
+
+  const optionsSnapshot = (Array.isArray(chosen.options) ? chosen.options : []).map(o => ({
+    groupName: o.groupName,
+    optionValue: o.optionValue,
+  }));
+
+  return { combination: chosen, optionsSnapshot };
+}
+
+/**
+ * Calculate final unit price from product base price/discountPrice and combination price/discountPrice
+ * @param {number} basePrice
+ * @param {number|undefined} baseDiscountPrice
+ * @param {{price:number,discountPrice?:number}|null} chosenCombination
+ */
+function calculateFinalUnitPrice(basePrice, baseDiscountPrice, chosenCombination) {
+  // If combination exists and has its own price/discountPrice, use them; else fall back to product base price
+  if (chosenCombination && typeof chosenCombination.price === 'number') {
+    const comboBase = chosenCombination;
+    const use =
+      typeof comboBase.discountPrice === 'number' && comboBase.discountPrice >= 0
+        ? comboBase.discountPrice
+        : comboBase.price;
+    return Math.max(0, use);
+  }
+  const use =
+    typeof baseDiscountPrice === 'number' && baseDiscountPrice >= 0 ? baseDiscountPrice : basePrice;
+  return Math.max(0, use);
+}
+
+/**
+ * Check SKUs are unique per seller across products using provided Product model.
+ * Note: Accepts ProductModel to avoid circular dependency when used from model hooks.
+ * @param {any} ProductModel - Mongoose model for Product (e.g., require('../Models/product.model'))
+ * @param {string|any} sellerId - createdBy of product (seller id)
+ * @param {string[]} skus - normalized SKUs to check
+ * @param {string|any} [excludeProductId] - product id to exclude when updating
+ * @returns {Promise<{ ok: boolean, conflict: any|null }>} - ok=false when conflict found
+ */
+async function checkSkuUniquePerSellerWithModel(ProductModel, sellerId, skus, excludeProductId) {
+  if (!Array.isArray(skus) || skus.length === 0) return { ok: true, conflict: null };
+  if (!sellerId) return { ok: true, conflict: null };
+  const filter = {
+    createdBy: sellerId,
+    'variantCombinations.sku': { $in: skus },
+  };
+  if (excludeProductId) filter._id = { $ne: excludeProductId };
+  const conflict = await ProductModel.findOne(filter).lean();
+  return { ok: !conflict, conflict };
+}
+
+module.exports = {
+  hasVariants,
+  validateVariantModelInput,
+  validateVariantImages,
+  resolveVariantSelection,
+  calculateFinalUnitPrice,
+  normalizeSku,
+  extractSkus,
+  validateSkuPayloadUniqueness,
+  checkSkuUniquePerSellerWithModel,
+};

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "seed:province": "node seeders/province-seeder.js",
     "seed:ward": "node seeders/ward-seeder.js",
     "seed:update-voucher-target": "node seeders/update-voucher-target.js",
+    "seed:product-variants-empty": "node seeders/update-product-variants-empty.js",
     "prepare": "husky install"
   },
   "dependencies": {

--- a/seeders/update-product-variants-empty.js
+++ b/seeders/update-product-variants-empty.js
@@ -1,0 +1,50 @@
+const mongoose = require('mongoose');
+const dotenv = require('dotenv');
+const Product = require('../Models/product.model');
+
+// Load environment variables
+dotenv.config();
+
+/**
+ * Seeder: Ensure legacy Product documents have variant fields initialized as empty arrays
+ * - Adds missing fields: variantGroups: [], variantCombinations: []
+ * - If fields exist but are not arrays, set them to []
+ */
+async function updateProductVariantsToEmpty() {
+  try {
+    await mongoose.connect(process.env.MONGO_URI);
+    console.log('✅ Connected to MongoDB');
+
+    const result = await Product.updateMany(
+      {
+        $or: [
+          { variantGroups: { $exists: false } },
+          { variantCombinations: { $exists: false } },
+          { variantGroups: { $not: { $type: 'array' } } },
+          { variantCombinations: { $not: { $type: 'array' } } },
+        ],
+      },
+      {
+        $set: {
+          variantGroups: [],
+          variantCombinations: [],
+        },
+      }
+    );
+
+    console.log(`🛠️ Updated documents: ${result.modifiedCount}`);
+  } catch (error) {
+    console.error('❌ Seeder failed:', error);
+    process.exit(1);
+  } finally {
+    await mongoose.connection.close();
+    console.log('🔌 Disconnected from MongoDB');
+    process.exit(0);
+  }
+}
+
+if (require.main === module) {
+  updateProductVariantsToEmpty();
+}
+
+module.exports = updateProductVariantsToEmpty;


### PR DESCRIPTION
### Description
- Link to Jira: https://duongrong2012-1743575833445.atlassian.net/browse/CB-46

---

### Summary
- [x] Update `Models/product.model.js`: add variant system `variantGroups` and `variantCombinations` with fields: `options[]`, `quantity`, `price`, `discountPrice`, `sku`, `image`
- [x] Remove `metadata` from `Product`; keep text index and paginate plugin
- [x] Add pre-save hook: auto-generate `slug`, validate variants, enforce SKU rules (unique within payload and unique per seller in DB)
- [x] Add variant utilities in `Utils/variant.utils.js`:
  `validateVariantModelInput`, `validateVariantImages`, `validateSkuPayloadUniqueness`, `checkSkuUniquePerSellerWithModel`, `resolveVariantSelection`, `calculateFinalUnitPrice`, `normalizeSku`, `extractSkus`
- [x] Standardize validation for create/update product in `Middlewares/validation.middleware.js`
  - Aggregate all non-DB errors and return once; return DB-related errors immediately
  - Auto-sync `quantity = sum(variantCombinations[].quantity)` on create when variants are present
  - Integrate rules for variants, SKU, and per-variant `image`
- [x] Update Swagger:
  - `OpenApi/product/create-product.yaml` and `OpenApi/product/update-product.yaml`: add `variantCombinations[].image`; add comprehensive examples (full/partial/add-new-variant/admin reject)
- [x] Add seeder to initialize empty variant fields for legacy products: `seeders/update-product-variants-empty.js` and script `npm run seed:product-variants-empty`
- [x] Update `README.md` with usage of the new seeder

---

### New and Updated Validation Rules

- Variants – structure and consistency
  - Presence symmetry: `variantGroups` and `variantCombinations` must be provided together
  - `variantGroups`:
    - `name`: non-empty, unique among groups
    - `options[].value`: non-empty, no duplicates within the same group
  - `variantCombinations`:
    - Exactly one option per group
    - Each option must exist in its corresponding group
    - `quantity >= 0`
    - `price >= 0` (required)
    - `discountPrice >= 0` and `<= price` when provided
    - Options set must be unique across combinations

- Variant image – `variantCombinations[].image` (optional)
  - If provided: non-empty string
  - Must be a valid `http`/`https` URL
  - File extension must be one of: `.jpg`, `.jpeg`, `.png`, `.webp`

- SKU – `variantCombinations[].sku` (optional)
  - Auto uppercased
  - No duplicates within the current payload
  - Unique per seller across all products (DB-checked)

- Quantity synchronization
  - On create with variants: auto-set `product.quantity = sum(variantCombinations[].quantity)`
  - On update: ensure effective data is valid and consistent with `quantity`

- Error response format (standardized)
  - `{ status: "error", code: 400, message: "Validation failed", errors: [{ field, message }] }`
  - Non-DB errors returned together; DB errors returned immediately